### PR TITLE
chore: 接続がうまくいかなかったため、botとDBのネットワーク設定をcompose.yamlに追加した

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,8 @@ services:
       - db
     environment:
       TZ: "Asia/Tokyo"
+    networks:
+      - discord_bot_network
   db:
     image: mysql:8.0.28
     platform: linux/amd64
@@ -29,6 +31,12 @@ services:
       TZ: "Asia/Tokyo"
     volumes:
       - discord_bot_db_data:/var/lib/mysql
+    networks:
+      - discord_bot_network
 
 volumes:
   discord_bot_db_data:
+
+networks:
+  discord_bot_network:
+    driver: bridge


### PR DESCRIPTION
## 概要
- BotとDBの接続設定をただcompose.yamlに追記しただけ
- ぶっちゃけこれでどんな効果があるかは厳密にわかってない